### PR TITLE
Customize env preset, include babel-plugin-lodash, fix preset configuration

### DIFF
--- a/packages/babel-preset-wtw-im/README.md
+++ b/packages/babel-preset-wtw-im/README.md
@@ -4,28 +4,54 @@
 
 # Install
 
-````bash
+```bash
 $ npm install --save-dev babel-preset-wtw-im
-````
+```
 
 # Usage
 
 ## Via `.babelrc` (Recommended)
 
 ### .babelrc
-````json
+```json
 {
   "presets": ["wtw-im"]
 }
-````
+```
 
 ### The React preset is included by default, there is an option to turn it off
 
-````json
+```json
 {
   "presets": [["wtw-im", { react: false }]]
 }
-````
+```
+
+### babel-preset-env is included. To customize pass in your env options
+
+For more information on available options, please refer to the [babel-preset-env documentation](https://babeljs.io/docs/plugins/preset-env/).
+
+#### .babelrc
+```json
+{
+  "presets": [["wtw-im", {
+    "env": {
+      "targets": { "browsers": "IE11" }
+    }
+  }]]
+}
+```
+
+#### Node API
+```js
+require("babel-core").transform("code", {
+  presets: [ ["wtw-im", {
+    env: {
+      targets: { browsers: "IE11" }
+    }
+  }] ]
+});
+```
 
 ### extract-format-message
 
@@ -33,7 +59,7 @@ The [extract-format-message](https://github.com/format-message/format-message/tr
 to `locales/en.json` using the default id generator.
 
 #### .babelrc
-```
+```json
 {
   "presets": [["wtw-im", { 
     "extractFormatMessage": {
@@ -41,6 +67,7 @@ to `locales/en.json` using the default id generator.
       "outFile": "my/locales/path.json"
     }
   }] ]
+}
 ```
 
 #### Node API
@@ -53,6 +80,16 @@ require("babel-core").transform("code", {
     }
   }] ]
 })
+```
+
+The plugin can be disabled by setting `extractFormatMessage` to false
+
+```json
+{
+  "presets": [["wtw-im", {
+    "extractFormatMessage" false
+  }]]
+}
 ```
 
 ### transform-format-message
@@ -84,6 +121,16 @@ require("babel-core").transform("code", {
     }
   }] ]
 })
+```
+
+The plugin can be disabled by setting `transformFormatMessage` to false
+
+```json
+{
+  "presets": [["wtw-im", {
+    "transformFormatMessage" false
+  }]]
+}
 ```
 
 ## Via CLI

--- a/packages/babel-preset-wtw-im/index.js
+++ b/packages/babel-preset-wtw-im/index.js
@@ -7,9 +7,12 @@ module.exports = function(context, options = {}) {
     [
       require('babel-preset-env'),
       Object.assign({}, env)
-    ],
-    (react === false ? null : require('babel-preset-react'))
+    ]
   ];
+
+  if (react !== false) {
+    presets.push(require('babel-preset-react'));
+  }
 
   const plugins = [
     require('babel-plugin-lodash'),

--- a/packages/babel-preset-wtw-im/index.js
+++ b/packages/babel-preset-wtw-im/index.js
@@ -1,10 +1,13 @@
 const defaultSettings = require('./default-settings');
 
 module.exports = function(context, options = {}) {
-  const { react, extractFormatMessage, transformFormatMessage } = options;
+  const { env, react, extractFormatMessage, transformFormatMessage } = options;
 
   const presets = [
-    require('babel-preset-env'),
+    [
+      require('babel-preset-env'),
+      Object.assign({}, env)
+    ],
     (react === false ? null : require('babel-preset-react'))
   ];
 

--- a/packages/babel-preset-wtw-im/index.js
+++ b/packages/babel-preset-wtw-im/index.js
@@ -14,16 +14,22 @@ module.exports = function(context, options = {}) {
   const plugins = [
     require('babel-plugin-lodash'),
     require('babel-plugin-transform-class-properties'),
-    require('babel-plugin-transform-object-rest-spread'),
-    extractFormatMessage !== false && [
+    require('babel-plugin-transform-object-rest-spread')
+  ];
+
+  if (extractFormatMessage !== false) {
+    plugins.push([
       require('babel-plugin-extract-format-message'),
       Object.assign({}, defaultSettings.extractFormatMessage, extractFormatMessage)
-    ],
-    transformFormatMessage !== false && [
+    ]);
+  }
+
+  if (transformFormatMessage !== false) {
+    plugins.push([
       require('babel-plugin-transform-format-message'),
       Object.assign({}, defaultSettings.transformFormatMessage, transformFormatMessage)
-    ]
-  ];
+    ]);
+  }
 
   return {
     presets,

--- a/packages/babel-preset-wtw-im/index.js
+++ b/packages/babel-preset-wtw-im/index.js
@@ -12,6 +12,7 @@ module.exports = function(context, options = {}) {
   ];
 
   const plugins = [
+    require('babel-plugin-lodash'),
     require('babel-plugin-transform-class-properties'),
     require('babel-plugin-transform-object-rest-spread'),
     extractFormatMessage !== false && [

--- a/packages/babel-preset-wtw-im/index.spec.js
+++ b/packages/babel-preset-wtw-im/index.spec.js
@@ -11,10 +11,10 @@ function findPlugin(pluginList, expectedPlugin) {
 
 it('can exclude react preset', () => {
   let { presets } = configPreset();
-  expect(presets[1]).not.toBeNull();
+  expect(presets[1]).toBe(require('babel-preset-react'));
 
   ({ presets } = configPreset(null, { react: false }));
-  expect(presets[1]).toBeNull();
+  expect(presets[1]).toBeUndefined();
 });
 
 describe('babel-plugin-extract-format-message', () => {

--- a/packages/babel-preset-wtw-im/index.spec.js
+++ b/packages/babel-preset-wtw-im/index.spec.js
@@ -1,6 +1,14 @@
 const configPreset = require('./index');
 const defaultSettings = require('./default-settings');
 
+function findPlugin(pluginList, expectedPlugin) {
+  return pluginList.find(plugin =>
+    Array.isArray(plugin)
+      ? plugin[0] === expectedPlugin
+      : plugin === expectedPlugin
+  );
+}
+
 it('can exclude react preset', () => {
   let { presets } = configPreset();
   expect(presets[1]).not.toBeNull();
@@ -10,37 +18,37 @@ it('can exclude react preset', () => {
 });
 
 describe('babel-plugin-extract-format-message', () => {
-  const extractFormatMessageIndex = 2;
+  const plugin = require('babel-plugin-extract-format-message');
 
   it('can be excluded', () => {
     let { plugins } = configPreset();
-    expect(plugins[extractFormatMessageIndex]).not.toBeNull();
+    expect(findPlugin(plugins, plugin)).not.toBeFalsy();
 
     ({ plugins } = configPreset(null, { extractFormatMessage: false }));
-    expect(plugins[extractFormatMessageIndex]).toBeFalsy();
+    expect(findPlugin(plugins)).toBeFalsy();
   });
 
   it('consumes the default options', () => {
     const { plugins } = configPreset();
-    const settings = plugins[extractFormatMessageIndex][1];
+    const settings = findPlugin(plugins, plugin)[1]
     expect(settings).toMatchObject(defaultSettings.extractFormatMessage);
   });
 });
 
 describe('babel-plugin-transform-format-message', () => {
-  const transformFormatMessageIndex = 3;
+  const plugin = require('babel-plugin-transform-format-message');
 
   it('can be excluded', () => {
     let { plugins } = configPreset();
-    expect(plugins[transformFormatMessageIndex ]).not.toBeNull();
+    expect(findPlugin(plugins, plugin)).not.toBeFalsy();
 
     ({ plugins } = configPreset(null, { transformFormatMessage: false }));
-    expect(plugins[transformFormatMessageIndex]).toBeFalsy();
+    expect(findPlugin(plugins, plugin)).toBeFalsy();
   });
 
   it('consume the default options', () => {
     const { plugins } = configPreset();
-    const settings = plugins[transformFormatMessageIndex][1];
+    const settings = findPlugin(plugins, plugin)[1]
     expect(settings).toMatchObject(defaultSettings.transformFormatMessage);
   });
 });

--- a/packages/babel-preset-wtw-im/package-lock.json
+++ b/packages/babel-preset-wtw-im/package-lock.json
@@ -372,6 +372,32 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-helper-module-imports": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-module-imports/-/babel-helper-module-imports-7.0.0-beta.3.tgz",
+      "integrity": "sha512-bdPrIXbUTYfREhRhjbN8SstwQaj0S4+rW4PKi1f2Wc5fizSh0hGYkfXUdiSSOgyTydm956tAyz4FrG61bqdQyw==",
+      "requires": {
+        "babel-types": "7.0.0-beta.3",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babel-types": {
+          "version": "7.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+          "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
+      }
+    },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
@@ -478,6 +504,18 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.2.0.tgz",
       "integrity": "sha512-NwicD5n1YQaj6sM3PVULdPBDk1XdlWvh8xBeUJg3nqZwp79Vofb8Q7GOVeWoZZ/RMlMuJMMrEAgSQl/p392nLA==",
       "dev": true
+    },
+    "babel-plugin-lodash": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.2.tgz",
+      "integrity": "sha512-lNsptTRfc0FTdW56O087EiKEADVEjJo2frDQ97olMjCKbRZfZPu7MvdyxnZLOoDpuTCtavN8/4Zk65x4gT+C3Q==",
+      "requires": {
+        "babel-helper-module-imports": "7.0.0-beta.3",
+        "babel-types": "6.26.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "require-package-name": "2.0.1"
+      }
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
@@ -1675,8 +1713,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.1.3",
@@ -2613,7 +2650,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2806,7 +2842,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -2815,8 +2850,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invariant": {
       "version": "2.2.2",
@@ -4263,7 +4297,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -4768,6 +4801,11 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
+    },
+    "require-package-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+      "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk="
     },
     "resolve": {
       "version": "1.1.7",
@@ -5362,8 +5400,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.3.0",

--- a/packages/babel-preset-wtw-im/package.json
+++ b/packages/babel-preset-wtw-im/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "babel-plugin-extract-format-message": "^5.2.1",
+    "babel-plugin-lodash": "^3.3.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-format-message": "^5.2.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",


### PR DESCRIPTION
* Enabling configuration of the `env` preset for future work in optimizing downstream packages for tree shaking.
* Adding in lodash plugin
* Fix broken configuration when setting format message plugins to false